### PR TITLE
Dev rev2

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -358,9 +358,12 @@ fn run_cmd(
 
     if command == "reset".to_string() {
         // reset the .env file
-        let _dot_env = std::fs::File::create(".env")?;
+        let mut dot_env = std::fs::File::create(".env")?;
+        let env: String = "tokenXRD=030000000000000000000000000000000000000000000000000004\n".to_string();
+        Ok(dot_env.write_all(env.as_bytes())?)
+    } else {
+        Ok(())   
     }
-    Ok(())
 }
 
 fn walk_entities(stdout: String) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -397,16 +400,9 @@ fn walk_entities(stdout: String) -> Result<Vec<String>, Box<dyn std::error::Erro
 
 fn append_env(mut env: String, ent: String) -> Result<(), Box<dyn std::error::Error>> {
     let mut dotenv = std::fs::OpenOptions::new().append(true).open(".env")?;
-    let mut special_case_xrd = false;
     env.push_str("=");
-    if env == "account=" {
-        special_case_xrd = true;
-    }
     env.push_str(&ent);
     env.push_str("\n");
-    if special_case_xrd {
-        env.push_str("tokenXRD=030000000000000000000000000000000000000000000000000004\n"); // hard-coded special case value
-    }
     Ok(dotenv.write_all(env.as_bytes())?)
 }
 


### PR DESCRIPTION
Adds new --rev (-r) option to read in and process resim commands from a human readable and editable file.

Supports the same magic for setting environment variables as we go.

Refactors the code a bit especially in run_cmd() so that run_file() shares much of the same logic as the new run_rev().

Handles the special case addition of adding tokenXRD in a smarter way (specifically add it after "reset" command is called.)