### PR TITLE
basic CI workflow for deploying to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Install
+      run: cargo install --verbose --path .
 
   publish:
     name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - develop
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - develop
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startswith(github.ref, 'refs/tags/v')
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cargo Publish
+      run: cargo publish --token ${{ secrets.CARGO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,24 @@
 name = "revup"
 version = "0.2.0"
 edition = "2018"
+authors = ["RadGuild"]
+description = "Resim rapid instantiator"
+license = "MIT"
+homepage = "https://github.com/RadGuild/revup"
+repository = "https://github.com/RadGuild/revup"
+keywords = ["scrypto", "radix", "cli", "resim", "revup"]
+categories = [
+  "cryptography::cryptocurrencies",
+  "development-tools",
+  "command-line-utilities"
+]
+readme = "README.md"
+include = [
+  "src/**/*",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE"
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # revup
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 ## Install
 
 ### Linux
@@ -111,6 +113,7 @@ Normal maintenace is underway. Feel free to add, comment upon or even fix an ope
 
 We also have defined some projects outlining future directions. To reward our developers and
 help us move forward with our plans. you may send a donation of XRD to:
+
 ```
 rdx1qspk7l8jfqmafwfcpzhx25p3qczj0nczqd9yvaux4892lrw2xgksnfgmkkr69
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ revup*.json
 
 ### Going forward:
 
-Normal maintenace is underway. Feel free to add, comment upon or even fix an open issue.
+Normal maintenance is underway. Feel free to add, comment upon or even fix an open issue.
 
 We also have defined some projects outlining future directions. To reward our developers and
 help us move forward with our plans. you may send a donation of XRD to:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 extern crate clap;
-use clap::{App, Arg, ArgGroup};
+use clap::{App, Arg, ArgGroup, crate_version};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{prelude::*};
@@ -62,7 +62,7 @@ struct Commands {
 fn main() {
     let matches =
         App::new("revup")
-            .version("v0.2.0")
+            .version(crate_version!())
             .author("author: RadGuild")
             .about(
                 "Sets up the resim simulator for calling functions instantly, looks for revup.json file in the current dir, and runs the resim commands in order storing the created entities address locations in a dotenv file. Run \">>> source .env\" after running revup and all your environment variables will be active in your shell.",


### PR DESCRIPTION
Closes #21 

NOTE: for deployments to work a crates.io API token must be generated and added to the CI secrets (CARGO_TOKEN)

This is a basic implementation that does the minimum required to publish the crate.

## Workflow

- All PRs and merges to the develop branch cause the workflow to run: checking out the project, building it and running any tests
- Pushing a new tag (for example `v0.2.1` will run the workflow and additionally publish the crate to crates.io
- After publishing a new release can be created via Github

## Future Improvements

- Additional badges on the readme
- Auto publish documentation
- Linting (`cargo clippy`)
- Formatting (`cargo fmt`)
- Auto release management (Github Action generates a release after publish)
- Changelogs
