### PR TITLE
support "epoch" command in .rev files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,8 @@ fn run_rev_file(mut reader: Box<dyn std::io::Read>) -> Result<(), Box<dyn std::e
                     }
                 }
             }
-            if cmd != "-e" {
+            
+            if cmd != "-e" && cmd != "epoch" {
                 run_cmd(cmd, args, envars)?;
             } else {
                 if c_a_str.len() > 1 {


### PR DESCRIPTION
This change allows users to use either `-e` or `epoch` to run epoch commands in `.rev` files.

Equivalent commands:
`-e 10` -> `epoch 10`
`-e` -> `epoch`